### PR TITLE
cmd_run(): fix use of uninitialized memory in case of spaces as command

### DIFF
--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -1110,6 +1110,11 @@ static int cmd_run(char *string_ptr)
     int argc, ret;
 
     tr_info("Executing cmd: '%s'", string_ptr);
+
+    // Initialize first argv to utilize the existing command-not-found -path in case of
+    // getting only whitespace(s) as command string.
+    argv[0] = "";
+
     char *command_str = MEM_ALLOC(MBED_CONF_CMDLINE_MAX_LINE_LENGTH);
     if (command_str == NULL) {
         tr_error("mem alloc failed in cmd_run");


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
If one gave a command which contains only spaces, the cmd_run() would
access uninitialized memory while seeking on command to execute.
Fix this by initializing enough of the variables to utilize existing
error handling paths.

Valgrind warning being fixed here:
---8<---8<---8<---
```
==24024== Conditional jump or move depends on uninitialised value(s)
==24024==    at 0x1204F7: cmd_find (ns_cmdline.c:913)
==24024==    by 0x120AD4: cmd_run (ns_cmdline.c:1135)
==24024==    by 0x11FFA6: cmd_next (ns_cmdline.c:681)
==24024==    by 0x1140C7: cmd_ready_cb(int) (cmd_commands.cpp:368)
==24024==    by 0x11FF35: cmd_ready (ns_cmdline.c:660)
==24024==    by 0x11FEB3: cmd_exe (ns_cmdline.c:632)
==24024==    by 0x12218D: cmd_execute (ns_cmdline.c:1804)
==24024==    by 0x121486: cmd_char_input (ns_cmdline.c:1441)
==24024==    by 0x113FA3: _serial_in_read() (cmd_commands.cpp:320)
==24024==    by 0x11408D: tasklet_serial_in_read (cmd_commands.cpp:360)
==24024==    by 0x1C9E2D: eventOS_scheduler_dispatch_event (event.c:339)
==24024==    by 0x1CBD74: event_loop_thread (ns_event_loop.c:77)
==24024==  Uninitialised value was created by a stack allocation
==24024==    at 0x120A04: cmd_run (ns_cmdline.c:1108)
```

## Related PRs
<none>


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
<none>

## Steps to Test or Reproduce
Original behavior: press space two times and then press enter.